### PR TITLE
feat(Data): add payload slice accessor `payload`

### DIFF
--- a/src/frame/data.rs
+++ b/src/frame/data.rs
@@ -49,6 +49,10 @@ impl<'d> Data<'d> {
         let idx = idx * 2;
         Some(BigEndian::read_u16(&self.data[idx..idx + 2]))
     }
+
+    pub fn payload(&self) -> &[u8] {
+        self.data
+    }
 }
 
 /// Data iterator


### PR DESCRIPTION
My use case is to parse rather large register block from modbus powermeter.

I do it by designing exactly matching struct, deriving `zerocopy::FromBytes` for it, and the just creating it from register payload bytes as received from the powermeter. Since `zerocopy` crate has support for endianness, it looks to me like nearly perfect way to parse structured data represented in flat modbus registers.

I see no reason to hide register payload from library user - let him exploit them :-)

Thanks.