### PR TITLE
add defmt feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,14 @@ all-features = true
 [dependencies]
 log = "0.4.26"
 byteorder = { version =  "1.5.0", default-features = false }
+defmt = {version = "1.0.1", optional = true}
 
 [features]
 default = ["tcp", "rtu"]
 tcp = []
 rtu = []
 std = ["byteorder/std"]
+defmt = ["dep:defmt"]
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -5,6 +5,7 @@ pub mod rtu;
 pub mod tcp;
 
 /// The type of decoding
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DecoderType {
     Request,

--- a/src/codec/rtu/mod.rs
+++ b/src/codec/rtu/mod.rs
@@ -12,6 +12,7 @@ pub use crate::frame::rtu::*;
 const MAX_FRAME_LEN: usize = 256;
 
 /// An extracted RTU PDU frame.
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DecodedFrame<'a> {
     pub slave: SlaveId,
@@ -19,6 +20,7 @@ pub struct DecodedFrame<'a> {
 }
 
 /// The location of all bytes that belong to the frame.
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FrameLocation {
     /// The index where the frame starts

--- a/src/codec/tcp/mod.rs
+++ b/src/codec/tcp/mod.rs
@@ -11,6 +11,7 @@ pub use crate::frame::tcp::*;
 const MAX_FRAME_LEN: usize = 256;
 
 /// An extracted TCP PDU frame.
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DecodedFrame<'a> {
     pub transaction_id: TransactionId,
@@ -19,6 +20,7 @@ pub struct DecodedFrame<'a> {
 }
 
 /// The location of all bytes that belong to the frame.
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FrameLocation {
     /// The index where the frame starts

--- a/src/error.rs
+++ b/src/error.rs
@@ -48,3 +48,30 @@ impl fmt::Display for Error {
         }
     }
 }
+
+#[cfg(feature = "defmt")]
+impl defmt::Format for Error {
+    fn format(&self, f: defmt::Formatter) {
+        match self {
+            Self::CoilValue(v) => defmt::write!(f, "Invalid coil value: {}", v),
+            Self::BufferSize => defmt::write!(f, "Invalid buffer size"),
+            Self::FnCode(fn_code) => defmt::write!(f, "Invalid function code: {=u8:#04x}", fn_code),
+            Self::ExceptionCode(code) => defmt::write!(f, "Invalid exception code: {=u8:#04x}", code),
+            Self::ExceptionFnCode(code) => {
+                defmt::write!(f, "Invalid exception function code: {=u8:#04x}", code)
+            }
+            Self::Crc(expected, actual) => defmt::write!(f,
+                "Invalid CRC: expected = {=u16:#06x}, actual = {=u16:#06x}",
+                expected, actual
+            ),
+            Self::ByteCount(cnt) => defmt::write!(f, "Invalid byte count: {}", cnt),
+            Self::LengthMismatch(length_field, pdu_len) => defmt::write!(f,
+                "Length Mismatch: Length Field: {}, PDU Len + 1: {}",
+                length_field, pdu_len
+            ),
+            Self::ProtocolNotModbus(protocol_id) => {
+                defmt::write!(f, "Protocol not Modbus(0), recieved {} instead", protocol_id)
+            }
+        }
+    }
+}

--- a/src/frame/coils.rs
+++ b/src/frame/coils.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::error::*;
 
 /// Packed coils
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Coils<'c> {
     pub(crate) data: RawData<'c>,
@@ -60,6 +61,7 @@ impl<'c> Coils<'c> {
 
 /// Coils iterator.
 // TODO: crate an generic iterator
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CoilsIter<'c> {
     cnt: usize,

--- a/src/frame/data.rs
+++ b/src/frame/data.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::error::*;
 
 /// Modbus data (u16 values)
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Data<'d> {
     pub(crate) data: RawData<'d>,
@@ -57,6 +58,7 @@ impl<'d> Data<'d> {
 
 /// Data iterator
 // TODO: crate a generic iterator
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DataIter<'d> {
     cnt: usize,

--- a/src/frame/rtu.rs
+++ b/src/frame/rtu.rs
@@ -4,12 +4,14 @@ use super::*;
 pub type SlaveId = u8;
 
 /// RTU header
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Header {
     pub slave: SlaveId,
 }
 
 /// RTU Request ADU
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RequestAdu<'r> {
     pub hdr: Header,
@@ -17,6 +19,7 @@ pub struct RequestAdu<'r> {
 }
 
 /// RTU Response ADU
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ResponseAdu<'r> {
     pub hdr: Header,

--- a/src/frame/tcp.rs
+++ b/src/frame/tcp.rs
@@ -3,18 +3,21 @@ use super::*;
 pub type TransactionId = u16;
 pub type UnitId = u8;
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Header {
     pub transaction_id: TransactionId,
     pub unit_id: UnitId,
 }
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RequestAdu<'r> {
     pub hdr: Header,
     pub pdu: RequestPdu<'r>,
 }
 
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ResponseAdu<'r> {
     pub hdr: Header,


### PR DESCRIPTION
Very simple feature, just added `defmt::Format` to all structs and enums with Debug so embedded environments can still debug without an allocator.

Would be nice to merge so I could use the official release as my dependency, but I'm not worried if you don't think this feature is worth adding.