### PR TITLE
Gate `defmt` behind `target_os="none"`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,17 +13,22 @@ rust-version = "1.85"
 [package.metadata.docs.rs]
 all-features = true
 
-[dependencies]
-log = "0.4.26"
-byteorder = { version =  "1.5.0", default-features = false }
-defmt = {version = "1.0.1", optional = true}
-
 [features]
 default = ["tcp", "rtu"]
 tcp = []
 rtu = []
 std = ["byteorder/std"]
 defmt = ["dep:defmt"]
+
+[dependencies]
+log = { version = "0.4.26" }
+byteorder = { version = "1.5.0", default-features = false }
+
+[target.'cfg(target_os = "none")'.dependencies]
+defmt = { version = "1.0.1", optional = true }
+
+
+
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -5,7 +5,7 @@ pub mod rtu;
 pub mod tcp;
 
 /// The type of decoding
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(all(feature = "defmt", target_os = "none"), derive(defmt::Format))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DecoderType {
     Request,

--- a/src/codec/rtu/mod.rs
+++ b/src/codec/rtu/mod.rs
@@ -12,7 +12,7 @@ pub use crate::frame::rtu::*;
 const MAX_FRAME_LEN: usize = 256;
 
 /// An extracted RTU PDU frame.
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(all(feature = "defmt", target_os = "none"), derive(defmt::Format))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DecodedFrame<'a> {
     pub slave: SlaveId,
@@ -20,7 +20,7 @@ pub struct DecodedFrame<'a> {
 }
 
 /// The location of all bytes that belong to the frame.
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(all(feature = "defmt", target_os = "none"), derive(defmt::Format))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FrameLocation {
     /// The index where the frame starts

--- a/src/codec/tcp/mod.rs
+++ b/src/codec/tcp/mod.rs
@@ -12,7 +12,7 @@ pub use crate::frame::tcp::*;
 const MAX_FRAME_LEN: usize = 256;
 
 /// An extracted TCP PDU frame.
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(all(feature = "defmt", target_os = "none"), derive(defmt::Format))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DecodedFrame<'a> {
     pub transaction_id: TransactionId,
@@ -21,7 +21,7 @@ pub struct DecodedFrame<'a> {
 }
 
 /// The location of all bytes that belong to the frame.
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(all(feature = "defmt", target_os = "none"), derive(defmt::Format))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FrameLocation {
     /// The index where the frame starts

--- a/src/error.rs
+++ b/src/error.rs
@@ -49,7 +49,7 @@ impl fmt::Display for Error {
     }
 }
 
-#[cfg(feature = "defmt")]
+#[cfg(all(feature = "defmt", target_os = "none"))]
 impl defmt::Format for Error {
     fn format(&self, f: defmt::Formatter) {
         match self {

--- a/src/frame/coils.rs
+++ b/src/frame/coils.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::error::*;
 
 /// Packed coils
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(all(feature = "defmt", target_os = "none"), derive(defmt::Format))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Coils<'c> {
     pub(crate) data: RawData<'c>,
@@ -61,7 +61,7 @@ impl<'c> Coils<'c> {
 
 /// Coils iterator.
 // TODO: crate an generic iterator
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(all(feature = "defmt", target_os = "none"), derive(defmt::Format))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CoilsIter<'c> {
     cnt: usize,

--- a/src/frame/data.rs
+++ b/src/frame/data.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::error::*;
 
 /// Modbus data (u16 values)
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(all(feature = "defmt", target_os = "none"), derive(defmt::Format))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Data<'d> {
     pub(crate) data: RawData<'d>,
@@ -58,7 +58,7 @@ impl<'d> Data<'d> {
 
 /// Data iterator
 // TODO: crate a generic iterator
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(all(feature = "defmt", target_os = "none"), derive(defmt::Format))]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DataIter<'d> {
     cnt: usize,

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -11,7 +11,7 @@ use byteorder::{BigEndian, ByteOrder};
 /// A Modbus function code.
 ///
 /// It is represented by an unsigned 8 bit integer.
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(all(feature = "defmt", target_os = "none"), derive(defmt::Format))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FunctionCode {
     /// Modbus Function Code: `01` (`0x01`).
@@ -158,7 +158,7 @@ pub(crate) type Quantity = u16;
 type RawData<'r> = &'r [u8];
 
 /// A request represents a message from the client (master) to the server (slave).
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(all(feature = "defmt", target_os = "none"), derive(defmt::Format))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Request<'r> {
     ReadCoils(Address, Quantity),
@@ -193,7 +193,7 @@ pub enum Request<'r> {
 }
 
 /// A server (slave) exception response.
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(all(feature = "defmt", target_os = "none"), derive(defmt::Format))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ExceptionResponse {
     pub function: FunctionCode,
@@ -201,12 +201,12 @@ pub struct ExceptionResponse {
 }
 
 /// Represents a message from the client (slave) to the server (master).
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(all(feature = "defmt", target_os = "none"), derive(defmt::Format))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RequestPdu<'r>(pub Request<'r>);
 
 /// Represents a message from the server (slave) to the client (master).
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(all(feature = "defmt", target_os = "none"), derive(defmt::Format))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ResponsePdu<'r>(pub Result<Response<'r>, ExceptionResponse>);
 
@@ -218,7 +218,7 @@ type EventCount = u16;
 type MessageCount = u16;
 
 /// The response data of a successfull request.
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(all(feature = "defmt", target_os = "none"), derive(defmt::Format))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Response<'r> {
     ReadCoils(Coils<'r>),
@@ -345,7 +345,7 @@ impl fmt::Display for Exception {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result { write!(f, "{}", self.get_name()) }
 }
 
-#[cfg(feature = "defmt")]
+#[cfg(all(feature = "defmt", target_os = "none"))]
 impl defmt::Format for Exception {
     fn format(&self, fmt: defmt::Formatter) { defmt::write!(fmt, "{}", self.get_name()) }
 }

--- a/src/frame/rtu.rs
+++ b/src/frame/rtu.rs
@@ -4,14 +4,14 @@ use super::*;
 pub type SlaveId = u8;
 
 /// RTU header
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(all(feature = "defmt", target_os = "none"), derive(defmt::Format))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Header {
     pub slave: SlaveId,
 }
 
 /// RTU Request ADU
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(all(feature = "defmt", target_os = "none"), derive(defmt::Format))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RequestAdu<'r> {
     pub hdr: Header,
@@ -19,7 +19,7 @@ pub struct RequestAdu<'r> {
 }
 
 /// RTU Response ADU
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(all(feature = "defmt", target_os = "none"), derive(defmt::Format))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ResponseAdu<'r> {
     pub hdr: Header,

--- a/src/frame/tcp.rs
+++ b/src/frame/tcp.rs
@@ -3,21 +3,21 @@ use super::*;
 pub type TransactionId = u16;
 pub type UnitId = u8;
 
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(all(feature = "defmt", target_os = "none"), derive(defmt::Format))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Header {
     pub transaction_id: TransactionId,
     pub unit_id: UnitId,
 }
 
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(all(feature = "defmt", target_os = "none"), derive(defmt::Format))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RequestAdu<'r> {
     pub hdr: Header,
     pub pdu: RequestPdu<'r>,
 }
 
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
+#[cfg_attr(all(feature = "defmt", target_os = "none"), derive(defmt::Format))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ResponseAdu<'r> {
     pub hdr: Header,


### PR DESCRIPTION
Does what it says.

You can always include the `defmt` feature, but it won't do anything unless you are running on bare metal. As far as I can tell there is no better solution.