### PR TITLE
Fix rtu request pdu length calculation

### DIFF
--- a/src/codec/rtu/mod.rs
+++ b/src/codec/rtu/mod.rs
@@ -147,9 +147,47 @@ pub const fn request_pdu_len(adu_buf: &[u8]) -> Result<Option<usize>> {
     let len = match fn_code {
         0x01..=0x06 => Some(5),
         0x07 | 0x0B | 0x0C | 0x11 => Some(1),
-        0x0F | 0x10 => {
-            if adu_buf.len() > 4 {
-                Some(6 + adu_buf[4] as usize)
+        0x0F => {
+            if adu_buf.len() > 6 {
+                let quantity = u16::from_be_bytes([adu_buf[4], adu_buf[5]]);
+                let bytes = adu_buf[6];
+
+                let expected_count = if quantity % 8 == 0 {
+                    quantity / 8
+                } else {
+                    quantity / 8 + 1
+                };
+
+                if expected_count == bytes as u16 {
+                    Some(6 + bytes as usize)
+                } else {
+                    return Err(Error::QuantityBytesMismatch(
+                        quantity,
+                        bytes,
+                        expected_count,
+                    ));
+                }
+            } else {
+                // incomplete frame
+                None
+            }
+        }
+
+        0x10 => {
+            if adu_buf.len() > 6 {
+                let quantity = u16::from_be_bytes([adu_buf[4], adu_buf[5]]);
+                let expected_count = quantity.saturating_mul(2);
+                let bytes = adu_buf[6];
+
+                if expected_count == adu_buf[6] as u16 {
+                    Some(6 + adu_buf[6] as usize)
+                } else {
+                    return Err(Error::QuantityBytesMismatch(
+                        quantity,
+                        bytes,
+                        expected_count,
+                    ));
+                }
             } else {
                 // incomplete frame
                 None
@@ -251,12 +289,40 @@ mod tests {
         assert_eq!(request_pdu_len(buf).unwrap(), Some(1));
 
         buf[1] = 0x0F;
-        buf[4] = 99;
+        buf[6] = 99;
+        assert_eq!(
+            request_pdu_len(buf),
+            Err(Error::QuantityBytesMismatch(0, 99, 0))
+        );
+
+        buf[1] = 0x10;
+        buf[6] = 99;
+        assert_eq!(
+            request_pdu_len(buf),
+            Err(Error::QuantityBytesMismatch(0, 99, 0))
+        );
+
+        buf[1] = 0x0F;
+        buf[5] = 99;
+        buf[6] = 99;
+        assert_eq!(
+            request_pdu_len(buf),
+            Err(Error::QuantityBytesMismatch(99, 99, 13))
+        );
+
+        buf[1] = 0x0F;
+        buf[4] = 0x03;
+        buf[5] = 0x14;
+        buf[6] = 99;
         assert_eq!(request_pdu_len(buf).unwrap(), Some(105));
 
         buf[1] = 0x10;
-        buf[4] = 99;
-        assert_eq!(request_pdu_len(buf).unwrap(), Some(105));
+        buf[4] = 0;
+        buf[5] = 49;
+        buf[6] = 98;
+        assert_eq!(request_pdu_len(buf).unwrap(), Some(104));
+        buf[4] = 0x00;
+        buf[5] = 0x00;
 
         buf[1] = 0x11;
         assert_eq!(request_pdu_len(buf).unwrap(), Some(1));

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,7 +25,11 @@ pub enum Error {
     /// Protocol not Modbus
     ProtocolNotModbus(u16),
     /// Length Mismatch
-    QuantityBytesMismatch(u16, u8, u16),
+    QuantityBytesMismatch {
+        quantity: u16,
+        bytes_expected: u16,
+        bytes: u8,
+    },
 }
 
 impl fmt::Display for Error {
@@ -50,7 +54,11 @@ impl fmt::Display for Error {
             Self::ProtocolNotModbus(protocol_id) => {
                 write!(f, "Protocol not Modbus(0), received {protocol_id} instead")
             }
-            Self::QuantityBytesMismatch(quantity, bytes, bytes_expected) => write!(
+            Self::QuantityBytesMismatch {
+                quantity,
+                bytes,
+                bytes_expected,
+            } => write!(
                 f,
                 "Quantity Byte Mismatch: quantity: {quantity}, bytes : {bytes}, bytes expected {bytes_expected}"
             ),
@@ -91,7 +99,11 @@ impl defmt::Format for Error {
                     protocol_id
                 )
             }
-            Self::QuantityBytesMismatch(quantity, bytes, bytes_expected) => defmt::write!(
+            Self::QuantityBytesMismatch {
+                quantity,
+                bytes,
+                bytes_expected,
+            } => defmt::write!(
                 f,
                 "Quantity Byte Mismatch: quantity: {}, bytes: {}, bytes expected: {}",
                 quantity,

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,6 +24,8 @@ pub enum Error {
     LengthMismatch(usize, usize),
     /// Protocol not Modbus
     ProtocolNotModbus(u16),
+    /// Length Mismatch
+    QuantityBytesMismatch(u16, u8, u16),
 }
 
 impl fmt::Display for Error {
@@ -48,6 +50,10 @@ impl fmt::Display for Error {
             Self::ProtocolNotModbus(protocol_id) => {
                 write!(f, "Protocol not Modbus(0), received {protocol_id} instead")
             }
+            Self::QuantityBytesMismatch(quantity, bytes, bytes_expected) => write!(
+                f,
+                "Quantity Byte Mismatch: quantity: {quantity}, bytes : {bytes}, bytes expected {bytes_expected}"
+            ),
         }
     }
 }
@@ -85,6 +91,13 @@ impl defmt::Format for Error {
                     protocol_id
                 )
             }
+            Self::QuantityBytesMismatch(quantity, bytes, bytes_expected) => defmt::write!(
+                f,
+                "Quantity Byte Mismatch: quantity: {}, bytes: {}, bytes expected: {}",
+                quantity,
+                bytes,
+                bytes_expected
+            ),
         }
     }
 }


### PR DESCRIPTION
PR to fix the request PDU length calculation mentioned in https://github.com/slowtec/modbus-core/issues/12. 

My application doesn't use coils but I've attempted to implement the fix for FC 0x0F as well. I have not looked at the TCP implementation at all (I have no experience with it). An error was also added for when the quantity and bytes fields don't match up.