### PR TITLE
Allow to disable logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,11 @@ tcp = []
 rtu = []
 std = ["byteorder/std"]
 defmt = ["dep:defmt"]
+# Enable decoding error logging.
+log = ["dep:log"]
 
 [dependencies]
-log = { version = "0.4.28" }
+log = { version = "0.4.28", optional = true }
 byteorder = { version = "1.5.0", default-features = false }
 
 [target.'cfg(target_os = "none")'.dependencies]

--- a/src/codec/rtu/client.rs
+++ b/src/codec/rtu/client.rs
@@ -40,10 +40,10 @@ pub fn decode_response(buf: &[u8]) -> Result<Option<ResponseAdu<'_>>> {
                 .or_else(|_| Response::try_from(pdu).map(|r| ResponsePdu(Ok(r))))
                 .map(|pdu| Some(ResponseAdu { hdr, pdu }));
             #[cfg(feature = "log")]
-            response.inspect_err(|&err| {
+            if let Err(error) = response {
                 // Unrecoverable error
-                log::error!("Failed to decode Response PDU: {err}");
-            });
+                log::error!("Failed to decode Response PDU: {error}");
+            }
             response
         })
         .map_err(|_| {

--- a/src/codec/rtu/client.rs
+++ b/src/codec/rtu/client.rs
@@ -35,14 +35,16 @@ pub fn decode_response(buf: &[u8]) -> Result<Option<ResponseAdu<'_>>> {
             // to transmission errors, because the frame's bytes
             // have already been verified with the CRC.
 
-            ExceptionResponse::try_from(pdu)
+            let response = ExceptionResponse::try_from(pdu)
                 .map(|er| ResponsePdu(Err(er)))
                 .or_else(|_| Response::try_from(pdu).map(|r| ResponsePdu(Ok(r))))
-                .map(|pdu| Some(ResponseAdu { hdr, pdu }))
-                .inspect_err(|&err| {
-                    // Unrecoverable error
-                    log::error!("Failed to decode Response PDU: {err}");
-                })
+                .map(|pdu| Some(ResponseAdu { hdr, pdu }));
+            #[cfg(feature = "log")]
+            response.inspect_err(|&err| {
+                // Unrecoverable error
+                log::error!("Failed to decode Response PDU: {err}");
+            });
+            response
         })
         .map_err(|_| {
             // Decoding the transport frame is non-destructive and must

--- a/src/codec/rtu/mod.rs
+++ b/src/codec/rtu/mod.rs
@@ -72,12 +72,14 @@ pub fn decode(
         })
         .or_else(|err| {
             if drop_cnt + 1 >= MAX_FRAME_LEN {
+                #[cfg(feature = "log")]
                 log::error!(
                     "Giving up to decode frame after dropping {drop_cnt} byte(s): {:X?}",
                     &buf[0..drop_cnt]
                 );
                 return Err(err);
             }
+            #[cfg(feature = "log")]
             log::warn!(
                 "Failed to decode {} frame: {err}",
                 match decoder_type {

--- a/src/codec/rtu/server.rs
+++ b/src/codec/rtu/server.rs
@@ -23,10 +23,10 @@ pub fn decode_request(buf: &[u8]) -> Result<Option<RequestAdu<'_>>> {
                 .map(|pdu| Some(RequestAdu { hdr, pdu }));
 
             #[cfg(feature = "log")]
-            request.inspect_err(|&err| {
+            if let Err(error) = request {
                 // Unrecoverable error
-                log::error!("Failed to decode request PDU: {err}");
-            });
+                log::error!("Failed to decode request PDU: {error}");
+            }
             request
         })
         .map_err(|_| {

--- a/src/codec/rtu/server.rs
+++ b/src/codec/rtu/server.rs
@@ -18,13 +18,16 @@ pub fn decode_request(buf: &[u8]) -> Result<Option<RequestAdu<'_>>> {
             // Decoding of the PDU should are unlikely to fail due
             // to transmission errors, because the frame's bytes
             // have already been verified with the CRC.
-            Request::try_from(pdu)
+            let request = Request::try_from(pdu)
                 .map(RequestPdu)
-                .map(|pdu| Some(RequestAdu { hdr, pdu }))
-                .inspect_err(|&err| {
-                    // Unrecoverable error
-                    log::error!("Failed to decode request PDU: {err}");
-                })
+                .map(|pdu| Some(RequestAdu { hdr, pdu }));
+
+            #[cfg(feature = "log")]
+            request.inspect_err(|&err| {
+                // Unrecoverable error
+                log::error!("Failed to decode request PDU: {err}");
+            });
+            request
         })
         .map_err(|_| {
             // Decoding the transport frame is non-destructive and must

--- a/src/codec/tcp/client.rs
+++ b/src/codec/tcp/client.rs
@@ -51,10 +51,10 @@ pub fn decode_response(buf: &[u8]) -> Result<Option<ResponseAdu<'_>>> {
                 .or_else(|_| Response::try_from(pdu).map(|r| ResponsePdu(Ok(r))))
                 .map(|pdu| Some(ResponseAdu { hdr, pdu }));
             #[cfg(feature = "log")]
-            response.inspect_err(|&err| {
+            if let Err(error) = response {
                 // Unrecoverable error
-                log::error!("Failed to decode Response PDU: {err}");
-            });
+                log::error!("Failed to decode Response PDU: {error}");
+            }
             response
         })
         .map_err(|_| {

--- a/src/codec/tcp/mod.rs
+++ b/src/codec/tcp/mod.rs
@@ -75,18 +75,22 @@ pub fn decode(
             }
         })
         .or_else(|err| {
-            let pdu_type = match decoder_type {
-                Request => "request",
-                Response => "response",
-            };
             if drop_cnt + 1 >= MAX_FRAME_LEN {
+                #[cfg(feature = "log")]
                 log::error!(
                     "Giving up to decode frame after dropping {drop_cnt} byte(s): {:X?}",
                     &buf[0..drop_cnt]
                 );
                 return Err(err);
             }
-            log::warn!("Failed to decode {pdu_type} frame: {err}");
+            #[cfg(feature = "log")]
+            log::warn!(
+                "Failed to decode {pdu_type} frame: {err}",
+                pdu_type = match decoder_type {
+                    Request => "request",
+                    Response => "response",
+                }
+            );
             drop_cnt += 1;
             retry = true;
             Ok(None)

--- a/src/codec/tcp/server.rs
+++ b/src/codec/tcp/server.rs
@@ -25,13 +25,15 @@ pub fn decode_request(buf: &[u8]) -> Result<Option<RequestAdu<'_>>> {
     // Decoding of the PDU should are unlikely to fail due
     // to transmission errors, because the frame's bytes
     // have already been verified at the TCP level.
-    Request::try_from(pdu)
+    let request = Request::try_from(pdu)
         .map(RequestPdu)
-        .map(|pdu| Some(RequestAdu { hdr, pdu }))
-        .inspect_err(|&err| {
-            // Unrecoverable error
-            log::error!("Failed to decode request PDU: {err}");
-        })
+        .map(|pdu| Some(RequestAdu { hdr, pdu }));
+    #[cfg(feature = "log")]
+    request.inspect_err(|&err| {
+        // Unrecoverable error
+        log::error!("Failed to decode request PDU: {err}");
+    });
+    request
 }
 
 // Decode a TCP response
@@ -56,16 +58,17 @@ pub fn decode_response(buf: &[u8]) -> Result<Option<ResponseAdu<'_>>> {
             // Decoding of the PDU should are unlikely to fail due
             // to transmission errors, because the frame's bytes
             // have already been verified at the TCP level.
-
-            Response::try_from(pdu)
+            let response = Response::try_from(pdu)
                 .map(Ok)
                 .or_else(|_| ExceptionResponse::try_from(pdu).map(Err))
                 .map(ResponsePdu)
-                .map(|pdu| Some(ResponseAdu { hdr, pdu }))
-                .inspect_err(|&err| {
-                    // Unrecoverable error
-                    log::error!("Failed to decode response PDU: {err}");
-                })
+                .map(|pdu| Some(ResponseAdu { hdr, pdu }));
+            #[cfg(feature = "log")]
+            response.inspect_err(|&err| {
+                // Unrecoverable error
+                log::error!("Failed to decode response PDU: {err}");
+            });
+            response
         })
         .map_err(|_| {
             // Decoding the transport frame is non-destructive and must

--- a/src/codec/tcp/server.rs
+++ b/src/codec/tcp/server.rs
@@ -29,10 +29,10 @@ pub fn decode_request(buf: &[u8]) -> Result<Option<RequestAdu<'_>>> {
         .map(RequestPdu)
         .map(|pdu| Some(RequestAdu { hdr, pdu }));
     #[cfg(feature = "log")]
-    request.inspect_err(|&err| {
+    if let Err(error) = request {
         // Unrecoverable error
-        log::error!("Failed to decode request PDU: {err}");
-    });
+        log::error!("Failed to decode request PDU: {error}");
+    }
     request
 }
 
@@ -64,10 +64,10 @@ pub fn decode_response(buf: &[u8]) -> Result<Option<ResponseAdu<'_>>> {
                 .map(ResponsePdu)
                 .map(|pdu| Some(ResponseAdu { hdr, pdu }));
             #[cfg(feature = "log")]
-            response.inspect_err(|&err| {
+            if let Err(error) = response {
                 // Unrecoverable error
-                log::error!("Failed to decode response PDU: {err}");
-            });
+                log::error!("Failed to decode response PDU: {error}");
+            }
             response
         })
         .map_err(|_| {


### PR DESCRIPTION
An application may want to do it's own logging using the returned errors.