### PR TITLE
Expose the MAX_FRAME_LEN constants

### DIFF
--- a/src/codec/rtu/mod.rs
+++ b/src/codec/rtu/mod.rs
@@ -12,7 +12,7 @@ pub use crate::frame::rtu::*;
 
 // [MODBUS over Serial Line Specification and Implementation Guide V1.02](http://modbus.org/docs/Modbus_over_serial_line_V1_02.pdf), page 13
 // "The maximum size of a MODBUS RTU frame is 256 bytes."
-const MAX_FRAME_LEN: usize = 256;
+pub const MAX_FRAME_LEN: usize = 256;
 
 /// An extracted RTU PDU frame.
 #[cfg_attr(all(feature = "defmt", target_os = "none"), derive(defmt::Format))]

--- a/src/codec/tcp/mod.rs
+++ b/src/codec/tcp/mod.rs
@@ -12,7 +12,7 @@ pub use crate::frame::tcp::*;
 
 // [MODBUS MESSAGING ON TCP/IP IMPLEMENTATION GUIDE V1.0b](http://modbus.org/docs/Modbus_Messaging_Implementation_Guide_V1_0b.pdf), page 18
 // "a MODBUS request needs a maximum of 256 bytes + the MBAP header size"
-const MAX_FRAME_LEN: usize = 256;
+pub const MAX_FRAME_LEN: usize = 256;
 
 /// An extracted TCP PDU frame.
 #[cfg_attr(all(feature = "defmt", target_os = "none"), derive(defmt::Format))]


### PR DESCRIPTION
These are useful for sizing receive buffers.