### PR TITLE
Add From and TryFrom implementations for Data

### DIFF
--- a/src/frame/data.rs
+++ b/src/frame/data.rs
@@ -61,6 +61,7 @@ impl<'d> Data<'d> {
 }
 
 /// The buffer has an invalid size (must be a non null multiple of 2).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct DataFromBufferError;
 
 impl<'buffer> TryFrom<&'buffer [u8]> for Data<'buffer> {
@@ -202,5 +203,60 @@ mod tests {
         assert!(data_iter.next().is_some());
         assert!(data_iter.next().is_some());
         assert!(data_iter.next().is_none());
+    }
+
+    #[test]
+    fn data_try_from() {
+        assert_eq!(
+            Data::try_from(&[] as &[u8]),
+            Err(DataFromBufferError),
+            "Data from empty buffer is not allowed"
+        );
+        assert_eq!(
+            Data::try_from(&[0u8] as &[u8]),
+            Err(DataFromBufferError),
+            "Data from buffer with length that is not a multiple of 2 is not allowed"
+        );
+        assert_eq!(
+            Data::try_from(&[0u8, 1, 2] as &[u8]),
+            Err(DataFromBufferError),
+            "Data from buffer with length that is not a multiple of 2 is not allowed"
+        );
+        assert_eq!(
+            Data::try_from(&[0u8, 1] as &[u8]),
+            Ok(Data {
+                data: &[0, 1],
+                quantity: 1
+            }),
+            "Data from buffer with even length must succeed"
+        );
+        assert_eq!(
+            Data::try_from(&0x1234_5678_u64.to_be_bytes() as &[u8]),
+            Ok(Data {
+                data: &0x1234_5678_u64.to_be_bytes(),
+                quantity: 4
+            }),
+            "Data from buffer with even length must succeed"
+        );
+    }
+
+    #[test]
+    fn data_from() {
+        assert_eq!(
+            Data::from(&[0u8, 1]),
+            Data {
+                data: &[0, 1],
+                quantity: 1
+            },
+            "Data from buffer with even length must succeed"
+        );
+        assert_eq!(
+            Data::from(&0x1234_5678_u64.to_be_bytes()),
+            Data {
+                data: &0x1234_5678_u64.to_be_bytes(),
+                quantity: 4
+            },
+            "Data from buffer with even length must succeed"
+        );
     }
 }


### PR DESCRIPTION
Sometimes a multi byte value is stored over a span of registers, e.g a 64bit value could be stored over 4 consecutive registers. When sending a request to write to such a register, one has to use `WriteMultipleRegisters(Address, Data<'r>)`, which requires a data.

If the rust code is using the value as a 64 bit integer, it is quite cumbersome to convert it to `&[u16]` that is required by `Data::from_words`, the only way to construct a `Data`.

This PR proposes some `TryFrom` and `From` implementations to help with these situations. You can now write
```rust
Data::from(&0x12345678_u64.to_be_bytes())
```

Since `From` can only be implemented for even number of bytes, a helper macro is used to declare implementations up to `[u8; 32]` (similar how `Default` is implemented for arrays [in the standard library](https://github.com/rust-lang/rust/blob/2f4dfc753fd86c672aa4145940db075a8a149f17/library/core/src/array/mod.rs#L499)).

One question: Why is constructing a zero length `Data` forbidden? I don't have a usecase, but should it be allowed?