### PR TITLE
Return `FrameLocation` from all `decode_*` functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ## v0.3.0 (unpublished)
 
 - Added `Slave` and `SlaveContext`
+- Merged `modbus_core::rtu::FrameLocation` and `modbus_core::tcp::FrameLocation` and moved it to `modbus_core::FrameLocation`
 
 ## v0.2.0 (2025-09-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 - Added `Slave` and `SlaveContext`
 - Merged `modbus_core::rtu::FrameLocation` and `modbus_core::tcp::FrameLocation` and moved it to `modbus_core::FrameLocation`
+- Return a `FrameLocation` in addition to the parsed frame in `rtu::server::decode_response`,
+  `rtu::client::decode_response`, `tcp::server::decode_response` and `tcp::client::decode_request`
 
 ## v0.2.0 (2025-09-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Merged `modbus_core::rtu::FrameLocation` and `modbus_core::tcp::FrameLocation` and moved it to `modbus_core::FrameLocation`
 - Return a `FrameLocation` in addition to the parsed frame in `rtu::server::decode_response`,
   `rtu::client::decode_response`, `tcp::server::decode_response` and `tcp::client::decode_request`
+- Added `FrameLocation::end` helper.
 
 ## v0.2.0 (2025-09-30)
 

--- a/src/codec/rtu/mod.rs
+++ b/src/codec/rtu/mod.rs
@@ -23,16 +23,6 @@ pub struct DecodedFrame<'a> {
     pub pdu: &'a [u8],
 }
 
-/// The location of all bytes that belong to the frame.
-#[cfg_attr(all(feature = "defmt", target_os = "none"), derive(defmt::Format))]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct FrameLocation {
-    /// The index where the frame starts
-    pub start: usize,
-    /// Number of bytes that belong to the frame
-    pub size: usize,
-}
-
 /// Decode RTU PDU frames from a buffer.
 pub fn decode(
     decoder_type: DecoderType,

--- a/src/codec/tcp/mod.rs
+++ b/src/codec/tcp/mod.rs
@@ -23,16 +23,6 @@ pub struct DecodedFrame<'a> {
     pub pdu: &'a [u8],
 }
 
-/// The location of all bytes that belong to the frame.
-#[cfg_attr(all(feature = "defmt", target_os = "none"), derive(defmt::Format))]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct FrameLocation {
-    /// The index where the frame starts
-    pub start: usize,
-    /// Number of bytes that belong to the frame
-    pub size: usize,
-}
-
 /// Decode TCP PDU frames from a buffer.
 pub fn decode(
     decoder_type: DecoderType,

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -21,6 +21,14 @@ pub struct FrameLocation {
     pub size: usize,
 }
 
+impl FrameLocation {
+    /// One past the last byte of the frame.
+    #[must_use]
+    pub const fn end(&self) -> usize {
+        self.start + self.size
+    }
+}
+
 /// A Modbus function code.
 ///
 /// It is represented by an unsigned 8 bit integer.
@@ -551,5 +559,12 @@ mod tests {
             3
         );
         // TODO: extend test
+    }
+
+    #[test]
+    fn frame_location_end() {
+        assert_eq!(FrameLocation { start: 0, size: 3 }.end(), 3);
+        assert_eq!(FrameLocation { start: 2, size: 3 }.end(), 5);
+        assert_eq!(FrameLocation { start: 2, size: 0 }.end(), 2);
     }
 }

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -11,6 +11,16 @@ pub(crate) mod tcp;
 pub use self::{coils::*, data::*};
 use byteorder::{BigEndian, ByteOrder};
 
+/// The location of all bytes that belong to the frame.
+#[cfg_attr(all(feature = "defmt", target_os = "none"), derive(defmt::Format))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FrameLocation {
+    /// The index where the frame starts
+    pub start: usize,
+    /// Number of bytes that belong to the frame
+    pub size: usize,
+}
+
 /// A Modbus function code.
 ///
 /// It is represented by an unsigned 8 bit integer.


### PR DESCRIPTION
Fixes #24 by returning the frame location when decoding a frame. Also added a small helper function on the `FrameLocation` to calculate the end byte, since this will be useful when splitting the remaining unparsed bytes from the input buffer.

I also noticed that `FrameLocation` was duplicated, so I merged them together and moved `FrameLocation` to the `frame` module, I hope that's ok.