### PR TITLE
Add the value to the WriteSingleCoil response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 - Merged `modbus_core::rtu::FrameLocation` and `modbus_core::tcp::FrameLocation` and moved it to `modbus_core::FrameLocation`
 - Return a `FrameLocation` in addition to the parsed frame in `rtu::server::decode_response`,
   `rtu::client::decode_response`, `tcp::server::decode_response` and `tcp::client::decode_request`
-- Added `FrameLocation::end` helper.
+- Added `FrameLocation::end` helper
+- Fix `WriteSingleCoil` responses not including the output value
 
 ## v0.2.0 (2025-09-30)
 

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -244,7 +244,7 @@ type MessageCount = u16;
 pub enum Response<'r> {
     ReadCoils(Coils<'r>),
     ReadDiscreteInputs(Coils<'r>),
-    WriteSingleCoil(Address),
+    WriteSingleCoil(Address, Coil),
     WriteMultipleCoils(Address, Quantity),
     ReadInputRegisters(Data<'r>),
     ReadHoldingRegisters(Data<'r>),
@@ -309,7 +309,7 @@ impl<'r> From<Response<'r>> for FunctionCode {
         match r {
             R::ReadCoils(_) => Self::ReadCoils,
             R::ReadDiscreteInputs(_) => Self::ReadDiscreteInputs,
-            R::WriteSingleCoil(_) => Self::WriteSingleCoil,
+            R::WriteSingleCoil(_, _) => Self::WriteSingleCoil,
             R::WriteMultipleCoils(_, _) => Self::WriteMultipleCoils,
             R::ReadInputRegisters(_) => Self::ReadInputRegisters,
             R::ReadHoldingRegisters(_) => Self::ReadHoldingRegisters,
@@ -402,7 +402,7 @@ impl Response<'_> {
     pub const fn pdu_len(&self) -> usize {
         match *self {
             Self::ReadCoils(coils) | Self::ReadDiscreteInputs(coils) => 2 + coils.packed_len(),
-            Self::WriteSingleCoil(_) => 3,
+            Self::WriteSingleCoil(_, _) => 5,
             Self::WriteMultipleCoils(_, _)
             | Self::WriteMultipleRegisters(_, _)
             | Self::WriteSingleRegister(_, _) => 5,
@@ -505,7 +505,7 @@ mod tests {
                 }),
                 2,
             ),
-            (WriteSingleCoil(0x0), 5),
+            (WriteSingleCoil(0x0, false), 5),
             (WriteMultipleCoils(0x0, 0x0), 0x0F),
             (
                 ReadInputRegisters(Data {


### PR DESCRIPTION
The output value was missing for the response of a `WriteSingleCoil` request. See the relevant section of the modbus specification:

<img width="670" height="763" alt="Section 6.5 of the modbus specification" src="https://github.com/user-attachments/assets/fcfb954d-ca02-482c-a5b3-1a8031ccf64a" />
